### PR TITLE
statsd: thread safe Flush

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,5 @@
 # statsd
 
- Statsd client which adheres to [statsd/client-interface](https://github.com/statsd/client-interface). A fork of github.com/cyberdelia/statsd.
+ Statsd client which adheres to
+[statsd/client-interface](https://github.com/statsd/client-interface). A fork of
+github.com/cyberdelia/statsd.

--- a/statsd.go
+++ b/statsd.go
@@ -3,12 +3,13 @@ package statsd
 import (
 	"bufio"
 	"fmt"
-	. "github.com/visionmedia/go-debug"
 	"io"
 	"math/rand"
 	"net"
 	"sync"
 	"time"
+
+	. "github.com/visionmedia/go-debug"
 )
 
 var debug = Debug("statsd")
@@ -163,8 +164,15 @@ func (c *Client) Unique(name string, value int, rate float64) error {
 	return c.send(name, rate, "%d|s", value)
 }
 
-// Flush flushes writes any buffered data to the network.
+// Flush flushes any buffered data to the network.
 func (c *Client) Flush() error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return c.flush()
+}
+
+// flush() flushes data to the network. The caller is expected to hold c.m.
+func (c *Client) flush() error {
 	return c.buf.Flush()
 }
 
@@ -199,7 +207,7 @@ func (c *Client) send(stat string, rate float64, format string, args ...interfac
 
 	// Flush data if we have reach the buffer limit
 	if c.buf.Available() < len(format) {
-		if err := c.Flush(); err != nil {
+		if err := c.flush(); err != nil {
 			return nil
 		}
 	}


### PR DESCRIPTION
Currently if you call Flush at the same time another thread is adding
metrics, you can end up with a data race. Instead ensure the caller of
Flush locks the Client before accessing the underlying buffer.