### PR TITLE
Add tags to increment requests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,5 @@
 # statsd
 
- Statsd client which adheres to [statsd/client-interface](https://github.com/statsd/client-interface). A fork of github.com/cyberdelia/statsd.
+ Statsd client which adheres to
+[statsd/client-interface](https://github.com/statsd/client-interface). A fork of
+github.com/cyberdelia/statsd.

--- a/millisecond_test.go
+++ b/millisecond_test.go
@@ -1,0 +1,33 @@
+package statsd
+
+import (
+	"testing"
+	"time"
+)
+
+var millisecondTests = []struct {
+	duration time.Duration
+	control  int
+}{
+	{
+		duration: 350 * time.Millisecond,
+		control:  350,
+	},
+	{
+		duration: 5 * time.Second,
+		control:  5000,
+	},
+	{
+		duration: 50 * time.Nanosecond,
+		control:  0,
+	},
+}
+
+func TestMilliseconds(t *testing.T) {
+	for i, mt := range millisecondTests {
+		value := millisecond(mt.duration)
+		if value != mt.control {
+			t.Errorf("%d: incorrect value, want %d, got %d", i, mt.control, value)
+		}
+	}
+}

--- a/statsd.go
+++ b/statsd.go
@@ -3,20 +3,20 @@ package statsd
 import (
 	"bufio"
 	"fmt"
-	. "github.com/visionmedia/go-debug"
 	"io"
 	"math/rand"
 	"net"
 	"sync"
 	"time"
+
+	. "github.com/visionmedia/go-debug"
 )
 
 var debug = Debug("statsd")
 
 const defaultBufSize = 512
 
-// Client is statsd client representing a
-// onnection to a statsd server.
+// Client is a statsd client representing a connection to a statsd server.
 type Client struct {
 	conn   net.Conn
 	buf    *bufio.Writer
@@ -158,7 +158,7 @@ func (c *Client) Annotate(name string, value string, args ...interface{}) error 
 	return c.send(name, 1, "%s|a", fmt.Sprintf(value, args...))
 }
 
-// Unique records unique occurences of events.
+// Unique records unique occurrences of events.
 func (c *Client) Unique(name string, value int, rate float64) error {
 	return c.send(name, rate, "%d|s", value)
 }

--- a/statsd.go
+++ b/statsd.go
@@ -163,8 +163,15 @@ func (c *Client) Unique(name string, value int, rate float64) error {
 	return c.send(name, rate, "%d|s", value)
 }
 
-// Flush flushes writes any buffered data to the network.
+// Flush flushes any buffered data to the network.
 func (c *Client) Flush() error {
+	c.m.Lock()
+	defer c.m.Unlock()
+	return c.flush()
+}
+
+// flush() flushes data to the network. The caller is expected to hold c.m.
+func (c *Client) flush() error {
 	return c.buf.Flush()
 }
 
@@ -199,7 +206,7 @@ func (c *Client) send(stat string, rate float64, format string, args ...interfac
 
 	// Flush data if we have reach the buffer limit
 	if c.buf.Available() < len(format) {
-		if err := c.Flush(); err != nil {
+		if err := c.flush(); err != nil {
 			return nil
 		}
 	}

--- a/statsd.go
+++ b/statsd.go
@@ -118,33 +118,33 @@ func (c *Client) AddTag(key, value string) {
 }
 
 // Increment increments the counter for the given bucket.
-func (c *Client) Increment(name string, count int64, rate float64) error {
-	return c.send(name, nil, rate, "%d|c", count)
+func (c *Client) Increment(name string, count int64, rate float64, tags ...[2]string) error {
+	return c.send(name, tags, rate, "%d|c", count)
 }
 
 // Incr increments the counter for the given bucket by 1 at a rate of 1.
-func (c *Client) Incr(name string) error {
-	return c.Increment(name, 1, 1)
+func (c *Client) Incr(name string, tags ...[2]string) error {
+	return c.Increment(name, 1, 1, tags...)
 }
 
 // IncrBy increments the counter for the given bucket by N at a rate of 1.
-func (c *Client) IncrBy(name string, n int64) error {
-	return c.Increment(name, n, 1)
+func (c *Client) IncrBy(name string, n int64, tags ...[2]string) error {
+	return c.Increment(name, n, 1, tags...)
 }
 
 // Decrement decrements the counter for the given bucket.
-func (c *Client) Decrement(name string, count int64, rate float64) error {
-	return c.Increment(name, -count, rate)
+func (c *Client) Decrement(name string, count int64, rate float64, tags ...[2]string) error {
+	return c.Increment(name, -count, rate, tags...)
 }
 
 // Decr decrements the counter for the given bucket by 1 at a rate of 1.
-func (c *Client) Decr(name string) error {
-	return c.Increment(name, -1, 1)
+func (c *Client) Decr(name string, tags ...[2]string) error {
+	return c.Increment(name, -1, 1, tags...)
 }
 
 // DecrBy decrements the counter for the given bucket by N at a rate of 1.
-func (c *Client) DecrBy(name string, value int64) error {
-	return c.Increment(name, -value, 1)
+func (c *Client) DecrBy(name string, value int64, tags ...[2]string) error {
+	return c.Increment(name, -value, 1, tags...)
 }
 
 // Duration records time spent for the given bucket with time.Duration.

--- a/statsd.go
+++ b/statsd.go
@@ -186,7 +186,9 @@ func (c *Client) flush() error {
 
 // Close closes the connection.
 func (c *Client) Close() error {
-	if err := c.Flush(); err != nil {
+	c.m.Lock()
+	defer c.m.Unlock()
+	if err := c.flush(); err != nil {
 		return err
 	}
 	c.buf = nil

--- a/statsd.go
+++ b/statsd.go
@@ -8,11 +8,7 @@ import (
 	"net"
 	"sync"
 	"time"
-
-	. "github.com/visionmedia/go-debug"
 )
-
-var debug = Debug("statsd")
 
 const defaultBufSize = 512
 
@@ -122,7 +118,7 @@ func (c *Client) AddTag(key, value string) {
 }
 
 // Increment increments the counter for the given bucket.
-func (c *Client) Increment(name string, count int, rate float64) error {
+func (c *Client) Increment(name string, count int64, rate float64) error {
 	return c.send(name, rate, "%d|c", count)
 }
 
@@ -132,12 +128,12 @@ func (c *Client) Incr(name string) error {
 }
 
 // IncrBy increments the counter for the given bucket by N at a rate of 1.
-func (c *Client) IncrBy(name string, n int) error {
+func (c *Client) IncrBy(name string, n int64) error {
 	return c.Increment(name, n, 1)
 }
 
 // Decrement decrements the counter for the given bucket.
-func (c *Client) Decrement(name string, count int, rate float64) error {
+func (c *Client) Decrement(name string, count int64, rate float64) error {
 	return c.Increment(name, -count, rate)
 }
 
@@ -147,7 +143,7 @@ func (c *Client) Decr(name string) error {
 }
 
 // DecrBy decrements the counter for the given bucket by N at a rate of 1.
-func (c *Client) DecrBy(name string, value int) error {
+func (c *Client) DecrBy(name string, value int64) error {
 	return c.Increment(name, -value, 1)
 }
 
@@ -157,12 +153,12 @@ func (c *Client) Duration(name string, duration time.Duration) error {
 }
 
 // Histogram is an alias of .Duration() until the statsd protocol figures its shit out.
-func (c *Client) Histogram(name string, value int) error {
+func (c *Client) Histogram(name string, value int64) error {
 	return c.send(name, 1, "%d|ms", value)
 }
 
 // Gauge records arbitrary values for the given bucket.
-func (c *Client) Gauge(name string, value int) error {
+func (c *Client) Gauge(name string, value int64) error {
 	return c.send(name, 1, "%d|g", value)
 }
 
@@ -172,7 +168,7 @@ func (c *Client) Annotate(name string, value string, args ...interface{}) error 
 }
 
 // Unique records unique occurrences of events.
-func (c *Client) Unique(name string, value int, rate float64) error {
+func (c *Client) Unique(name string, value int64, rate float64) error {
 	return c.send(name, rate, "%d|s", value)
 }
 
@@ -218,7 +214,6 @@ func (c *Client) send(stat string, rate float64, format string, args ...interfac
 	if c.tags != "" {
 		format = format + "|#" + c.tags
 	}
-	debug(format, args...)
 
 	// Flush data if we have reach the buffer limit
 	if c.buf.Available() < len(format) {

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -1,14 +1,14 @@
-package statsd
-
-import "github.com/statsd/client-interface"
+package statsd_test
 
 import (
 	"bytes"
 	"testing"
 	"time"
+
+	"github.com/meterup/statsd-client"
 )
 
-var client statsd.Client = &Client{}
+// var client statsd.Client = &statsd.Client{}
 
 func assert(t *testing.T, value, control string) {
 	if value != control {
@@ -18,7 +18,7 @@ func assert(t *testing.T, value, control string) {
 
 func TestPrefix(t *testing.T) {
 	buf := new(bytes.Buffer)
-	c := NewClient(buf)
+	c := statsd.NewClient(buf)
 	c.Prefix("foo.bar.baz.")
 	err := c.Increment("incr", 1, 1)
 	if err != nil {
@@ -30,7 +30,7 @@ func TestPrefix(t *testing.T) {
 
 func TestIncr(t *testing.T) {
 	buf := new(bytes.Buffer)
-	c := NewClient(buf)
+	c := statsd.NewClient(buf)
 	err := c.Incr("incr")
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +41,7 @@ func TestIncr(t *testing.T) {
 
 func TestDecr(t *testing.T) {
 	buf := new(bytes.Buffer)
-	c := NewClient(buf)
+	c := statsd.NewClient(buf)
 	err := c.Decr("decr")
 	if err != nil {
 		t.Fatal(err)
@@ -52,7 +52,7 @@ func TestDecr(t *testing.T) {
 
 func TestDuration(t *testing.T) {
 	buf := new(bytes.Buffer)
-	c := NewClient(buf)
+	c := statsd.NewClient(buf)
 	err := c.Duration("timing", time.Duration(123456789))
 	if err != nil {
 		t.Fatal(err)
@@ -63,7 +63,7 @@ func TestDuration(t *testing.T) {
 
 func TestGauge(t *testing.T) {
 	buf := new(bytes.Buffer)
-	c := NewClient(buf)
+	c := statsd.NewClient(buf)
 	err := c.Gauge("gauge", 300)
 	if err != nil {
 		t.Fatal(err)
@@ -74,7 +74,7 @@ func TestGauge(t *testing.T) {
 
 func TestAnnotate(t *testing.T) {
 	buf := new(bytes.Buffer)
-	c := NewClient(buf)
+	c := statsd.NewClient(buf)
 	err := c.Annotate("deploys", "deploying api 1.2.3")
 	if err != nil {
 		t.Fatal(err)
@@ -83,36 +83,9 @@ func TestAnnotate(t *testing.T) {
 	assert(t, buf.String(), "deploys:deploying api 1.2.3|a")
 }
 
-var millisecondTests = []struct {
-	duration time.Duration
-	control  int
-}{
-	{
-		duration: 350 * time.Millisecond,
-		control:  350,
-	},
-	{
-		duration: 5 * time.Second,
-		control:  5000,
-	},
-	{
-		duration: 50 * time.Nanosecond,
-		control:  0,
-	},
-}
-
-func TestMilliseconds(t *testing.T) {
-	for i, mt := range millisecondTests {
-		value := millisecond(mt.duration)
-		if value != mt.control {
-			t.Errorf("%d: incorrect value, want %d, got %d", i, mt.control, value)
-		}
-	}
-}
-
 func TestMultiPacket(t *testing.T) {
 	buf := new(bytes.Buffer)
-	c := NewClient(buf)
+	c := statsd.NewClient(buf)
 	err := c.Unique("unique", 765, 1)
 	if err != nil {
 		t.Fatal(err)
@@ -127,7 +100,7 @@ func TestMultiPacket(t *testing.T) {
 
 func TestMultiPacketOverflow(t *testing.T) {
 	buf := new(bytes.Buffer)
-	c := NewClient(buf)
+	c := statsd.NewClient(buf)
 	for i := 0; i < 40; i++ {
 		err := c.Unique("unique", 765, 1)
 		if err != nil {

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -72,6 +72,30 @@ func TestGauge(t *testing.T) {
 	assert(t, buf.String(), "gauge:300|g")
 }
 
+func TestGaugeTags(t *testing.T) {
+	buf := new(bytes.Buffer)
+	c := statsd.NewClient(buf)
+	t.Run("NoTagsOnClient", func(t *testing.T) {
+		err := c.Gauge("gauge", 300, [][2]string{{"five", "six"}, {"seven", "eight"}}...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c.Flush()
+		assert(t, buf.String(), "gauge:300|g|#five:six,seven:eight")
+		buf.Reset()
+	})
+	t.Run("TagsOnClient", func(t *testing.T) {
+		c.AddTag("one", "two")
+		c.AddTag("three", "four")
+		err := c.Gauge("gauge", 300, [][2]string{{"five", "six"}, {"seven", "eight"}}...)
+		if err != nil {
+			t.Fatal(err)
+		}
+		c.Flush()
+		assert(t, buf.String(), "gauge:300|g|#one:two,three:four,five:six,seven:eight")
+	})
+}
+
 func TestAnnotate(t *testing.T) {
 	buf := new(bytes.Buffer)
 	c := statsd.NewClient(buf)

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -1,11 +1,11 @@
-package statsd_test
+package statsd
 
 import (
 	"bytes"
 	"testing"
 	"time"
 
-	"github.com/meterup/statsd-client"
+	statsd "github.com/statsd/client"
 )
 
 // var client statsd.Client = &statsd.Client{}


### PR DESCRIPTION
Allows callers of `Increment()` and `Decrement()` to pass in tags
in order to segment requests like is supported with `Gauge()`.
